### PR TITLE
Avoid error when using in api only mode

### DIFF
--- a/lib/audit-log/engine.rb
+++ b/lib/audit-log/engine.rb
@@ -13,7 +13,7 @@ module AuditLog
     AuditLog::LogSubscriber.attach_to :audit_log
 
     initializer 'audit-log.assets.precompile', group: :all do |app|
-      app.config.assets.precompile += %w[audit-log/application.css]
+      app.config.assets.precompile += %w[audit-log/application.css] if app.config.respond_to?(:assets)
     end
   end
 end


### PR DESCRIPTION
When using in API only mode, running `rails g audit_log:install` will result in `method_missing': undefined method `assets' for #<Rails::Application:...`, there might be a better way to detect api only mode application, but for now, simply check the assets attribute existence